### PR TITLE
Update documentation and add postcss-pseudo-classes as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9426,7 +9426,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -11625,7 +11624,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -12019,7 +12017,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -12027,8 +12024,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colorette": {
       "version": "1.2.1",
@@ -14137,8 +14133,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.3",
@@ -17292,8 +17287,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -25576,7 +25570,6 @@
       "version": "7.0.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
       "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
-      "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -25586,14 +25579,12 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -25812,7 +25803,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/postcss-pseudo-classes/-/postcss-pseudo-classes-0.3.0.tgz",
       "integrity": "sha512-kimffn5E9/CMlXPaeEDF5hSiLnOj9RjMjnaQBXlnnQtokCrDH/RMPNT5DaVkm4HQIepMdxoKG9ers1HFrkx3Ww==",
-      "dev": true,
       "requires": {
         "postcss": "^7.0.0"
       }
@@ -29901,7 +29891,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
   },
   "author": "philippone",
   "license": "MIT",
+  "dependencies": {
+    "postcss-pseudo-classes": "0.3.0"
+  },
   "devDependencies": {
     "@angular/core": "9.1.7",
     "@babel/core": "7.11.6",
@@ -92,7 +95,6 @@
     "lint-staged": "10.4.0",
     "lit-html": "1.3.0",
     "postcss-loader": "4.0.2",
-    "postcss-pseudo-classes": "0.3.0",
     "prettier": "2.1.2",
     "pretty-quick": "3.0.2",
     "ts-jest": "26.4.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "postcss-pseudo-classes": "0.3.0"
   },
   "peerDependencies": {
-    "postcss-loader": "4"
+    "postcss-loader": "^4"
   },
   "devDependencies": {
     "@angular/core": "9.1.7",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
   "dependencies": {
     "postcss-pseudo-classes": "0.3.0"
   },
+  "peerDependencies": {
+    "postcss-loader": "4"
+  },
   "devDependencies": {
     "@angular/core": "9.1.7",
     "@babel/core": "7.11.6",

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -243,15 +243,32 @@ You can enable a toolbar button that toggles the Pseudo States in the Preview ar
 
 See [Framework Support](#framework-support) which Frameworks support this feature.
 
-Enable the button by adding it to your `main.js` file (located in the Storybook config directory):
+Enable the button by adding it to your addon configuration file (located in the Storybook config directory)
+
+<details>
+<summary>For version < 5.3.x</summary>
+
+Import the addon in your *addons.js* file:
 
 ```js
-// main.js
-
-module.exports = {
-  addons: ['@ergosign/storybook-addon-pseudo-states-react/register'],
-};
+import "@ergosign/storybook-addon-pseudo-states-react/register";
 ```
+</details>
+
+<details>
+<summary>For version >= 5.3.x</summary>
+
+Add it to the *addons* section in your *main.js* file.
+
+```js
+module.exports = {
+  "addons": [
+    '@ergosign/storybook-addon-pseudo-states-react/register'
+  ]
+}
+```
+
+</details>
 
 ### Usage
 

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -210,7 +210,7 @@ your own rule on which the plugin looks for your css classes.
 Per default, the prefix used in the addon to look for css classes is `\:`.
 To add the needed styles you have to add fakle classes consisting of `prefix` + `pseudostate` by yourself.
 
-For example: When you want to the states of *hover* and *focus* to be shown by the plugin, you
+For example: When you want the *hover* and *focus* states to be shown by the plugin, you
 have to add `\:hover` and `\:focus` classes to your styles by yourself.
 
 For the default prefix this may look like this:

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -299,39 +299,6 @@ storiesOf('Button', module)
 
 There is a default configuration for `selector`, `pseudos` and `attributes`. Thus, you can leave `withPseudo` options empty.
 
-### With React
-
-When using [CSS Modules](https://github.com/css-modules/css-modules), you must use automatically styling generation via `postcss-loader` (see [Styling section](#Styling)).
-
-`attributes` enable component's props.
-
-```js
-import { withPseudo } from '@ergosign/storybook-addon-pseudo-states-react';
-
-storiesOf('Button', module)
-  .addDecorator(withPseudo)
-  .addParameters({
-    withPseudo: {
-      attributes: [], // no attributes to show --> overwrite default [DISABLE]
-    },
-  })
-  .add('Button', () => <Button label="I'm a normal button" />)
-
-  .addParameters({
-    withPseudo: {
-        pseudo: [...PseudoStatesDefault, 'hover & focus'],
-        attributes: [
-          ...AttributesStatesDefault,
-          'selected',
-          'error',
-          'isLoading',
-          'isReady',
-        ]
-    },
-  })
-  .add('Button', () => <Button label="I'm a normal button" />);
-```
-
 #### Parameters & Types
 
 See [Types](../share/types.ts)

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -27,7 +27,8 @@ First of all, you need to install Pseudo States into your project as a dev depen
 npm install @ergosign/storybook-addon-pseudo-states-react --save-dev
 ```
 
-Then, configure it as an addon for your Storybook environment (located in the Storybook config directory).
+When using *create-react-app* and the related preset, configure it as an addon
+for your Storybook environment (located in the Storybook config directory).
 
 <details>
 <summary>For version < 5.3.x</summary>
@@ -55,22 +56,20 @@ module.exports = {
 
 </details>
 
-To display the pseudo states, you have to add specific css classes to your styling, see [Styling](#Styling)
+In case you have an other project configuration, check out the [Manual Setup](#manual-settup)
+section, to see how to get it working with different settings.
 
-Then, you can set the decorator locally, see [Usage](#Usage).
+To see what's needed to use the pseudo addon, have a look at the [Usage](#usage) section.
 
-### Styling
+### Setup
 
-#### With Preset
+#### With PostCSS Preset
 
 Preset-Postcss adds [postcss-loader](https://github.com/postcss/postcss-loader) to Storybook's custom webpack config.
 
-You must also install [postcss-pseudo-classes](https://github.com/giuseppeg/postcss-pseudo-classes).
-Unfortunately, latest version is only tagged and not released. Please use at least [tagged version 0.3.0](https://github.com/giuseppeg/postcss-pseudo-classes/releases/tag/v0.3.0)
+> This project comes with a dependency to the [postcss-pseudo-classes](https://github.com/giuseppeg/postcss-pseudo-classes) package.
+> Unfortunately, the latest version is only tagged and not released.
 
-```bash
-npm install postcss-pseudo-classes@0.3.0 --save-dev
-```
 
 Then add the preset `preset-postcss` to your configuration in `main.js` (located in the Storybook config directory):
 

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -204,8 +204,16 @@ module.exports = {
 
 #### Manually
 
-In addition to the standard pseudo state styling, you have to add fake classes consisting of `prefix` + `pseudostate` (`\:hover`, `\:focus`, `\:active`, `\:yourOwnState`) by yourself.
-Be aware that default prefix is `\:`. When using your own prefix, update your styling accordingly.
+When you do not want that the pseudo classes are generated for you, you can provide
+your own rule on which the plugin looks for your css classes.
+
+Per default, the prefix used in the addon to look for css classes is `\:`.
+To add the needed styles you have to add fakle classes consisting of `prefix` + `pseudostate` by yourself.
+
+For example: When you want to the states of *hover* and *focus* to be shown by the plugin, you
+have to add `\:hover` and `\:focus` classes to your styles by yourself.
+
+For the default prefix this may look like this:
 
 ```scss
 .element {
@@ -221,7 +229,9 @@ Be aware that default prefix is `\:`. When using your own prefix, update your st
 <details>
 <summary>With a custom prefix</summary>
 
-custom prefix: `.pseudoclass--`
+If you want to specify your own prefix, set it as *prefix* value in the addons *parameters* object.
+
+To change the prefix to `.pseudoclass--` you have to adjust the parameter like this:
 
 ```js
 // in your story
@@ -232,6 +242,8 @@ parameters: {
     }
 }
 ```
+
+And use the specified prefix in your styling definition:
 
 ```scss
 .element {

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -27,7 +27,39 @@ First of all, you need to install Pseudo States into your project as a dev depen
 npm install @ergosign/storybook-addon-pseudo-states-react --save-dev
 ```
 
-Then, configure it as an addon by adding it to your addons.js file (located in the Storybook config directory).
+Then, configure it as an addon for your Storybook environment (located in the Storybook config directory).
+
+<details>
+<summary>For version < 5.3.x</summary>
+
+Import the addon in your *addons.js* file:
+
+```js
+import "@ergosign/storybook-addon-pseudo-states-react/preset-postcss";
+```
+
+</details>
+
+<details>
+<summary>For version >= 5.3.x</summary>
+
+Add it to the *addons* section in your *main.js* file.
+
+```js
+module.exports = {
+  "stories": [
+    "../src/**/*.stories.mdx",
+    "../src/**/*.stories.@(js|jsx|ts|tsx)"
+  ],
+  "addons": [
+    "@storybook/addon-essentials",
+    "@storybook/preset-create-react-app",
+    '@ergosign/storybook-addon-pseudo-states-react/preset-postcss',
+  ]
+}
+```
+
+</details>
 
 To display the pseudo states, you have to add specific css classes to your styling, see [Styling](#Styling)
 

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -47,14 +47,8 @@ Add it to the *addons* section in your *main.js* file.
 
 ```js
 module.exports = {
-  "stories": [
-    "../src/**/*.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx)"
-  ],
   "addons": [
-    "@storybook/addon-essentials",
-    "@storybook/preset-create-react-app",
-    '@ergosign/storybook-addon-pseudo-states-react/preset-postcss',
+    '@ergosign/storybook-addon-pseudo-states-react/preset-postcss'
   ]
 }
 ```

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -56,12 +56,12 @@ module.exports = {
 
 </details>
 
-In case you have an other project configuration, check out the [Manual Setup](#manual-settup)
+In case you have an other project configuration, check out the [Advanced setup](#advanced-settup)
 section, to see how to get it working with different settings.
 
 To see what's needed to use the pseudo addon, have a look at the [Usage](#usage) section.
 
-### Setup
+### Advanced setup
 
 #### With PostCSS Preset
 

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -65,21 +65,37 @@ To see what's needed to use the pseudo addon, have a look at the [Usage](#usage)
 
 #### With PostCSS Preset
 
-Preset-Postcss adds [postcss-loader](https://github.com/postcss/postcss-loader) to Storybook's custom webpack config.
-
 > This project comes with a dependency to the [postcss-pseudo-classes](https://github.com/giuseppeg/postcss-pseudo-classes) package.
 > Unfortunately, the latest version is only tagged and not released.
 
+We provide a *preset-postcss* preset that adds [postcss-loader](https://github.com/postcss/postcss-loader) to Storybook's custom webpack config.
+Add this preset to your configuration (located in the Storybook config directory)
 
-Then add the preset `preset-postcss` to your configuration in `main.js` (located in the Storybook config directory):
+<details>
+<summary>For version < 5.3.x</summary>
+
+Import the addon in your *addons.js* file:
 
 ```js
-main.js;
-
-module.exports = {
-  presets: ['@ergosign/storybook-addon-pseudo-states-react/preset-postcss'],
-};
+import "@ergosign/storybook-addon-pseudo-states-react/preset-postcss";
 ```
+
+</details>
+
+<details>
+<summary>For version >= 5.3.x</summary>
+
+Add it to the *addons* section in your *main.js* file.
+
+```js
+module.exports = {
+  "addons": [
+    '@ergosign/storybook-addon-pseudo-states-react/preset-postcss'
+  ]
+}
+```
+
+</details>
 
 This creates for each css pseudo class an equivalent as normal css class (for instance `:hover` to `\:hover`), so that 
 you can use it in element's class attribute (`<div class=":hover">Element in hover state</div>`).
@@ -117,7 +133,13 @@ addParameters({
 
 #### Own Webpack config (but automatically generated with PostCss)
 
-Add [postcss-loader](https://github.com/postcss/postcss-loader) to a Storybook custom webpack config
+When you have configured your own webpack config but still want to use this addon
+with PostCSS, add [postcss-loader](https://github.com/postcss/postcss-loader) to you
+webpack config.
+
+> **ATTENTION**:
+> When using CSS-Modules, you have to take care that no `[hash]` is used as *localIdentName*
+> in your *css-loader* options.
 
 ```js
 module.exports = {
@@ -153,13 +175,7 @@ module.exports = {
 };
 ```
 
-Add [postcss-pseudo-classes](https://github.com/giuseppeg/postcss-pseudo-classes).
-
-```bash
-npm install postcss-pseudo-classes --save-dev
-```
-
-And enable it in `postcss.config.js`
+Aditionally, you have to enable the postcss-peudo-classes module it your `postcss.config.js`
 
 ```js
 module.exports = {

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -35,7 +35,7 @@ Then, you can set the decorator locally, see [Usage](#Usage).
 
 ### Styling
 
-### With Preset
+#### With Preset
 
 Preset-Postcss adds [postcss-loader](https://github.com/postcss/postcss-loader) to Storybook's custom webpack config.
 

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -269,7 +269,7 @@ There is a default configuration for `selector`, `pseudos` and `attributes`. Thu
 
 ### With React
 
-When using [CSS Modules](https://github.com/css-modules/css-modules), you must use automatically styling generation via `postcss-loader` (see [Styling section](###Styling)).
+When using [CSS Modules](https://github.com/css-modules/css-modules), you must use automatically styling generation via `postcss-loader` (see [Styling section](#Styling)).
 
 `attributes` enable component's props.
 


### PR DESCRIPTION
Besides of the documentation update, I moved the *postcss-pseudo-classes* package to the *dependencies* section.

If you want to have this change in a separate pull request I can move it back again so that this PR consists only of documentation changes.