### PR TITLE
Update Storybook addon metadata

### DIFF
--- a/src/lit/package.json
+++ b/src/lit/package.json
@@ -13,7 +13,9 @@
     "components",
     "tool",
     "ui",
-    "user interface"
+    "user interface",
+    "storybook-addon",
+    "style"
   ],
   "repository": {
     "type": "git",
@@ -52,5 +54,8 @@
     "access": "public",
     "scope": "@ergosign"
   },
-  "gitHead": "813bbe45fb060b4a4bfd5fecd2cf62ae9c46df5f"
+  "gitHead": "813bbe45fb060b4a4bfd5fecd2cf62ae9c46df5f",
+  "storybook": {
+    "icon": "https://avatars2.githubusercontent.com/u/12492523?s=200&v=4"
+  }
 }


### PR DESCRIPTION
Hey Ergosign! We've created a catalog of Storybook addons and yours is included: https://storybook.js.org/addons/@ergosign/storybook-addon-pseudo-states-lit

To make your addon more discoverable in the catalog, we've curated some of its metadata, and I've included those edits in this PR.

To learn more about the catalog metadata, check out our documentation: https://storybook.js.org/docs/react/addons/addon-catalog
