### PR TITLE
docs: typo in example

### DIFF
--- a/src/react/README.md
+++ b/src/react/README.md
@@ -328,7 +328,7 @@ storiesOf('Button', module)
   .addParameters({
     withPseudo: {
       selector: 'button', // css selector of pseudo state's host element
-      pseudo: ['focus', 'hover', 'hover & focus', 'active'],
+      pseudos: ['focus', 'hover', 'hover & focus', 'active'],
       attributes: ['disabled', 'readonly', 'error'],
     },
   })


### PR DESCRIPTION
`pseudos` was incorrectly mentioned as `pseudo` in an example.